### PR TITLE
consider file name containing spaces

### DIFF
--- a/Object Pascal.sublime-build
+++ b/Object Pascal.sublime-build
@@ -30,7 +30,7 @@
             "cmd": ["fpc", "-S2", "${file}", "&&", "start", "cmd", "/c", "chcp 1251 && CLS && $file_base_name.exe & echo. & echo. & pause"]
         },
         "osx": {
-            "shell_cmd": "fpc -S2 '${file_base_name}' && open -a Terminal.app '${file_path}/${file_base_name}' && clear",
+            "shell_cmd": "fpc -S2 '${file}' && open -a Terminal.app '${file_path}/${file_base_name}' && clear",
         },
 
     }

--- a/Object Pascal.sublime-build
+++ b/Object Pascal.sublime-build
@@ -11,10 +11,10 @@
         "name": "Run",
         "shell": true,
         "linux": {
-            "cmd": ["gnome-terminal -e 'bash -c \"${file_path}/${file_base_name};echo;echo;  echo Press ENTER to continue; read line;exit; exec bash\"'"]
+            "cmd": ["gnome-terminal -e 'bash -c \"\\\"${file_path}/${file_base_name}\\\";echo;echo;  echo Press ENTER to continue; read line;exit; exec bash\"'"]
         },
         "osx": {
-            "shell_cmd": "open -a Terminal.app ${file_path}/${file_base_name} && clear",
+            "shell_cmd": "open -a Terminal.app '${file_path}/${file_base_name}' && clear",
         },
         "windows": {
             "cmd": ["start", "cmd", "/c", "chcp 1251 && CLS && $file_base_name.exe & echo. & echo. & pause"]
@@ -23,11 +23,14 @@
     {
         "name": "Build and Run",
         "shell": true,
+        "linux": {
+            "cmd": ["fpc -S2 \"${file}\" && gnome-terminal -e 'bash -c \"\\\"${file_path}/${file_base_name}\\\";echo;echo;  echo Press ENTER to continue; read line;exit; exec bash\"'"]
+        },
         "windows": {
             "cmd": ["fpc", "-S2", "${file}", "&&", "start", "cmd", "/c", "chcp 1251 && CLS && $file_base_name.exe & echo. & echo. & pause"]
         },
         "osx": {
-            "shell_cmd": "fpc ${file_base_name} && open -a Terminal.app ${file_path}/${file_base_name} && clear",
+            "shell_cmd": "fpc -S2 '${file_base_name}' && open -a Terminal.app '${file_path}/${file_base_name}' && clear",
         },
 
     }

--- a/Object Pascal.sublime-build
+++ b/Object Pascal.sublime-build
@@ -17,7 +17,7 @@
             "shell_cmd": "open -a Terminal.app '${file_path}/${file_base_name}' && clear",
         },
         "windows": {
-            "cmd": ["start", "cmd", "/c", "chcp 1251 && CLS && $file_base_name.exe & echo. & echo. & pause"]
+            "shell_cmd": "start cmd /c \"chcp 1251 && CLS && \"$file_base_name.exe\" & echo. & echo. & pause\""
         }
     },
     {
@@ -27,7 +27,7 @@
             "cmd": ["fpc -S2 \"${file}\" && gnome-terminal -e 'bash -c \"\\\"${file_path}/${file_base_name}\\\";echo;echo;  echo Press ENTER to continue; read line;exit; exec bash\"'"]
         },
         "windows": {
-            "cmd": ["fpc", "-S2", "${file}", "&&", "start", "cmd", "/c", "chcp 1251 && CLS && $file_base_name.exe & echo. & echo. & pause"]
+            "shell_cmd": "fpc -S2 \"${file}\" && start cmd /c \"chcp 1251 && CLS && \"$file_base_name.exe\" & echo. & echo. & pause\""
         },
         "osx": {
             "shell_cmd": "fpc -S2 '${file}' && open -a Terminal.app '${file_path}/${file_base_name}' && clear",


### PR DESCRIPTION
1) add a "Build and Run" in Linux version
2) make "Build and Run" in OSX version the same as that in "cmd"
3) fix the bug it can't run correctly when file name or path contains
spaces